### PR TITLE
Errata: "omit events" to "emit events"

### DIFF
--- a/content/docs/errata/_index.md
+++ b/content/docs/errata/_index.md
@@ -7,3 +7,5 @@ bookToc: false
 # Errata
 
 pg. 98 s/processers/processors/
+
+pg. 171 s/should omit events/should emit events/


### PR DESCRIPTION
This one was tricky because the typo makes grammatical sense, but reverses the logic. 😅